### PR TITLE
fix: using pip3 directly not pip symlink

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,7 +81,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-lambda"
-version = "0.1.0"
+version = "0.2.1"
 dependencies = [
  "atty",
  "cargo-zigbuild",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cargo-lambda"
 description = "Cargo subcommand to work with AWS Lambda"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 license = "MIT"
 readme = "README.md"

--- a/src/main.rs
+++ b/src/main.rs
@@ -132,13 +132,13 @@ fn check_zig_installation() -> Result<()> {
 
     if atty::isnt(atty::Stream::Stdin) {
         println!("Zig is not installed in your system.\nYou can use any of the following options to install it:");
-        println!("\t* pip install ziglang (Python 3 required)");
+        println!("\t* pip3 install ziglang (Python 3 required)");
         println!("\t* npm install -g @ziglang/cli (NPM required)");
         println!("\t* Download a recent version from https://ziglang.org/download/ and add it to your PATH");
         return Err(miette::miette!("Install Zig and run cargo-lambda again"));
     }
 
-    let options = vec![InstallOption::Pip, InstallOption::Npm];
+    let options = vec![InstallOption::Pip3, InstallOption::Npm];
     let choice = inquire::Select::new(
         "Zig is not installed in your system.\nHow do you want to install Zig?",
         options,
@@ -152,14 +152,14 @@ fn check_zig_installation() -> Result<()> {
 }
 
 enum InstallOption {
-    Pip,
+    Pip3,
     Npm,
 }
 
 impl std::fmt::Display for InstallOption {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            InstallOption::Pip => write!(f, "Install with Pip (Python 3)"),
+            InstallOption::Pip3 => write!(f, "Install with Pip3 (Python 3)"),
             InstallOption::Npm => write!(f, "Install with NPM"),
         }
     }
@@ -169,7 +169,7 @@ impl InstallOption {
     fn install(self) -> Result<()> {
         let pb = Progress::start("Installing Zig...");
         let result = match self {
-            InstallOption::Pip => install_with_pip(),
+            InstallOption::Pip3 => install_with_pip3(),
             InstallOption::Npm => install_with_npm(),
         };
         let finish = if result.is_ok() {
@@ -183,19 +183,19 @@ impl InstallOption {
     }
 }
 
-fn install_with_pip() -> Result<()> {
-    let mut child = Command::new("pip")
+fn install_with_pip3() -> Result<()> {
+    let mut child = Command::new("pip3")
         .args(&["install", "ziglang"])
         .stderr(Stdio::null())
         .stdout(Stdio::null())
         .spawn()
         .into_diagnostic()
-        .wrap_err("Failed to run `pip install ziglang`")?;
+        .wrap_err("Failed to run `pip3 install ziglang`")?;
 
     let status = child
         .wait()
         .into_diagnostic()
-        .wrap_err("Failed to wait on pip process")?;
+        .wrap_err("Failed to wait on pip3 process")?;
     if !status.success() {
         std::process::exit(status.code().unwrap_or(1));
     }


### PR DESCRIPTION
Using the `pip3` command directly rather than the `pip` command,
which is symbolically linked to either `pip2` or `pip3`.

On macOS `pip` is generally not present even with Python 3 installed,
see https://apple.stackexchange.com/questions/371929/why-do-i-only-have-pip3-but-no-pip.
Therefore installation of Zig will fail, even though Python 3 and
`pip3` are installed.

E.g. version `0.2.0`

```
  >>> ./target/debug/cargo-lambda lambda build
? Zig is not installed in your system.
How do you want to install Zig? Install with Pip (Python 3)
▪▪▪▪▪ Failed to install Zig
Error:
  × Failed to run `pip install ziglang`
  ╰─▶ No such file or directory (os error 2)

  1 >>> which pip
pip not found

  1 >>> which pip3
/usr/local/bin/pip3
```