### PR TITLE
Use my published fork

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,7 +217,7 @@ dependencies = [
  "strum",
  "strum_macros",
  "tokio",
- "tokio-graceful-shutdown",
+ "tokio-graceful-shutdown-without-anyhow",
  "tower-http",
  "tracing",
  "tracing-subscriber",
@@ -787,9 +787,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad5c14e80759d0939d013e6ca49930e59fc53dd8e5009132f76240c179380c09"
+checksum = "efaa7b300f3b5fe8eb6bf21ce3895e1751d9665086af2d64b42f19701015ff4f"
 
 [[package]]
 name = "lock_api"
@@ -898,9 +898,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba42135c6a5917b9db9cd7b293e5409e1c6b041e6f9825e92e55a894c63b6f8"
+checksum = "52da4364ffb0e4fe33a9841a98a3f3014fb964045ce4f7a45a398243c8d6b0c9"
 dependencies = [
  "libc",
  "log",
@@ -1638,7 +1638,7 @@ dependencies = [
  "bytes",
  "libc",
  "memchr",
- "mio 0.8.1",
+ "mio 0.8.2",
  "num_cpus",
  "once_cell",
  "parking_lot 0.12.0",
@@ -1650,9 +1650,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-graceful-shutdown"
-version = "0.5.0"
-source = "git+https://github.com/calavera/tokio-graceful-shutdown?branch=remove_anyhow#fdb1ed37128ee68932b588e757e9e84729e47220"
+name = "tokio-graceful-shutdown-without-anyhow"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bb06801a4a0d061285228e0922dfd1673e3b60edd1f5ffe8b16ea3e82ef25fe"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -2010,9 +2011,9 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "4.2.4"
+version = "4.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a5a7e487e921cf220206864a94a89b6c6905bfc19f1057fa26a4cb360e5c1d2"
+checksum = "5c4fb54e6113b6a8772ee41c3404fb0301ac79604489467e0a9ce1f3e97c24ae"
 dependencies = [
  "either",
  "lazy_static",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ rustc_version = "0.4.0"
 strum = "0.24.0" # For String -> Enum macros for usage with the CLI.
 strum_macros = "0.24.0"
 tokio = { version = "1.17.0", features = ["full"] }
-tokio-graceful-shutdown = { git = "https://github.com/calavera/tokio-graceful-shutdown", branch = "remove_anyhow" }
+tokio-graceful-shutdown-without-anyhow = "0.6.0"
 tower-http = { version = "0.2.5", features = ["catch-panic", "request-id", "trace"] }
 tracing = "0.1.32"
 tracing-subscriber = { version = "0.3.9", features = ["env-filter"] }


### PR DESCRIPTION
Cargo doesn't allow you to publish crates with git dependencies.
Use my own published fork until changes are merged and released
upstream.

Signed-off-by: David Calavera <david.calavera@gmail.com>