### PR TITLE
Support environment variables.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,6 +217,8 @@ dependencies = [
  "opentelemetry-aws",
  "reqwest",
  "rustc_version",
+ "serde",
+ "serde_json",
  "strum",
  "strum_macros",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,8 @@ opentelemetry = { version = "0.17.0", features = ["trace", "rt-tokio"] }
 opentelemetry-aws = "0.5.0"
 reqwest = { version = "0.11.10", default-features = false, features = ["rustls-tls"] }
 rustc_version = "0.4.0"
+serde = { version = "1.0.136", features = ["derive"] }
+serde_json = "1.0.79"
 strum = "0.24.0" # For String -> Enum macros for usage with the CLI.
 strum_macros = "0.24.0"
 thiserror = "1.0.30"

--- a/README.md
+++ b/README.md
@@ -90,6 +90,47 @@ The start subcommand emulates the AWS Lambda control plane API. Run this command
 cargo lambda start
 ```
 
+The function is not compiled until the first time that you try to execute. See the [invoke](#invoke) command to learn how to execute a function. Cargo will run the command `cargo run --bin FUNCTION_NAME` to try to compile the function. `FUNCTION_NAME` can be either the name of the package if the package has only one binary, or the binary name in the `[[bin]]` section if the package includes more than one binary.
+
+### Start - Environment variables
+
+If you need to set environment variables for your function to run, you can specify them in the metadata section of your Cargo.toml file.
+
+Use the section `package.metadata.lambda.env` to set global variables that will applied to all functions in your package:
+
+```toml
+[package]
+name = "basic-lambda"
+
+[package.metadata.lambda.env]
+RUST_LOG = "debug"
+MY_CUSTOM_ENV_VARIABLE = "custom value"
+```
+
+If you have more than one function in the same package, and you want to set specific variables for each one of them, you can use a section named after each one of the binaries in your package, `package.metadata.lambda.bin.BINARY_NAME`:
+
+```toml
+[package]
+name = "lambda-project"
+
+[package.metadata.lambda.env]
+RUST_LOG = "debug"
+
+[[package.metadata.lambda.bin.get-product]]
+GET_PRODUCT_ENV_VARIABLE = "custom value"
+
+[[package.metadata.lambda.bin.add-product]]
+ADD_PRODUCT_ENV_VARIABLE = "custom value"
+
+[[bin]]
+name = "get-product"
+path = "src/bin/get-product.rs"
+
+[[bin]]
+name = "add-product"
+path = "src/bin/add-product.rs"
+```
+
 ### Invoke
 
 The invoke subcomand helps you send requests to the control plane emulator. To use this subcommand, you have to provide the name of the Lambda function that you want to invoke, and the payload that you want to send. When the control plane emulator receives the request, it will compile your Lambda function and handle your request.

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ use clap::{Parser, Subcommand};
 use miette::{miette, Result};
 mod build;
 mod invoke;
+mod metadata;
 mod progress;
 mod start;
 mod zig;

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -1,0 +1,73 @@
+use cargo_metadata::Package;
+use miette::{IntoDiagnostic, Result, WrapErr};
+use serde::Deserialize;
+use std::{collections::HashMap, path::PathBuf};
+
+#[derive(Default, Deserialize)]
+#[non_exhaustive]
+pub(crate) struct Metadata {
+    #[serde(default)]
+    pub lambda: LambdaMetadata,
+}
+
+#[derive(Clone, Default, Deserialize)]
+#[non_exhaustive]
+pub(crate) struct LambdaMetadata {
+    #[serde(default)]
+    pub env: HashMap<String, String>,
+    #[serde(default)]
+    pub bin: HashMap<String, PackageMetadata>,
+}
+
+#[derive(Clone, Default, Deserialize)]
+#[non_exhaustive]
+pub(crate) struct PackageMetadata {
+    #[serde(default)]
+    pub env: HashMap<String, String>,
+}
+
+pub(crate) fn binary_packages(manifest_path: PathBuf) -> Result<HashMap<String, Package>> {
+    let mut metadata_cmd = cargo_metadata::MetadataCommand::new();
+    metadata_cmd.no_deps();
+    metadata_cmd.manifest_path(manifest_path);
+    let metadata = metadata_cmd.exec().into_diagnostic()?;
+
+    let mut binaries = HashMap::new();
+    for pkg in metadata.packages {
+        let mut bin_name = None;
+        for target in &pkg.targets {
+            if target.kind.iter().any(|s| s == "bin") {
+                bin_name = Some(target.name.clone());
+                break;
+            }
+        }
+        if let Some(name) = bin_name {
+            binaries.insert(name, pkg);
+        }
+    }
+
+    Ok(binaries)
+}
+
+pub(crate) fn function_metadata(
+    manifest_path: PathBuf,
+    name: &str,
+) -> Result<Option<PackageMetadata>> {
+    let binaries = binary_packages(manifest_path)?;
+    let package = match binaries.get(name) {
+        None => return Ok(None),
+        Some(p) => p,
+    };
+
+    let metadata: Metadata = serde_json::from_value(package.metadata.clone())
+        .into_diagnostic()
+        .wrap_err("invalid lambda metadata in Cargo.toml file")?;
+
+    let mut env = HashMap::new();
+    env.extend(metadata.lambda.env);
+    if let Some(bin) = metadata.lambda.bin.get(name) {
+        env.extend(bin.env.clone());
+    }
+
+    Ok(Some(PackageMetadata { env }))
+}


### PR DESCRIPTION
Use the package.metadata section in Cargo.toml to provide
environment variables.

Fixes #23 

Signed-off-by: David Calavera <david.calavera@gmail.com>