### PR TITLE
Extract binaries from targets

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -116,7 +116,18 @@ impl Build {
         };
 
         let base = target_dir.join(final_target).join(profile);
-        for name in binaries.keys() {
+
+        let binaries = binaries
+            .values()
+            .flat_map(|package| {
+                package
+                    .targets
+                    .iter()
+                    .filter(|target| target.kind.iter().any(|k| k == "bin"))
+            })
+            .map(|target| target.name.as_str());
+
+        for name in binaries {
             let binary = base.join(name);
             if binary.exists() {
                 let bootstrap_dir = lambda_dir.join(name);


### PR DESCRIPTION
When running cargo-lamba on a multi-binary project, multiple `[[bin]]` entries in the Cargo.toml, only the first binary will be picked up as a lambda binary.

When a package contains multiple binaries, each binary is in the
package list. This change will get the name of the binary from the package
where the target.kind is "bin", instead of the using the package name.

This has been tested on both a single binary project and a multi-binary project.