### PR TITLE
Bring back pull_request events

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-on: [push]
+on: [push, pull_request]
 
 name: Build
 


### PR DESCRIPTION
Otherwise GitHub doesn't try to run workflows for forks.