### PR TITLE
fix: ignore glibc version in `--target` for checks

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -40,7 +40,10 @@ impl Build {
                 // Validate that the build target is supported in AWS Lambda
                 check_build_target(target)?;
                 // Same explicit target as host target
-                if host_target == target {
+                //
+                // Note: check with *starts with* instead of equality, as
+                // the `--target` might have a trailing glibc version.
+                if target.starts_with(host_target) {
                     self.build.disable_zig_linker = true
                 }
             }
@@ -62,7 +65,7 @@ impl Build {
             .build
             .target
             .get(0)
-            .map(|x| x.as_str())
+            .map(|x| x.split_once('.').map(|(t, _)| t).unwrap_or(x.as_str()))
             .unwrap_or("x86_64-unknown-linux-gnu");
         let profile = match self.build.profile.as_deref() {
             Some("dev" | "test") => "debug",


### PR DESCRIPTION
I found a minor bug when doing local testing with a `cargo install --path .` approach: if I pass a target along with glibc version like `x86_64-unknown-linux-musl.2.17`, it tries to install the target component as it includes glibc part when checking if it's installed in the toolchain. Ideally, it should exclude the part after `.` in the final target which we run checks against.

These changes should fix following issues:
* when determining same target as host, use `starts_with` instead, in case `--target` has a trailing glibc part
* when checking if target is installed in toolchain, use the target name before the `.`, so we can omit the glibc part in the check
