### PR TITLE
Allow running `invoke` without a function name

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -293,6 +293,7 @@ version = "0.1.0"
 dependencies = [
  "axum",
  "cargo-lambda-interactive",
+ "cargo-lambda-invoke",
  "cargo-lambda-metadata",
  "clap",
  "http-api-problem",

--- a/README.md
+++ b/README.md
@@ -135,10 +135,24 @@ path = "src/bin/add-product.rs"
 
 ### Invoke
 
-The invoke subcomand helps you send requests to the control plane emulator. To use this subcommand, you have to provide the name of the Lambda function that you want to invoke, and the payload that you want to send. If you don't know how to find your function's name, it can be in two places:
+The invoke subcomand helps you send requests to the control plane emulator.
+
+If your Rust project only includes one function, in the package's main.rs file, you can invoke it by sending the data that you want to process, without extra arguments. For example:
+
+```
+$ cargo lambda invoke --data-ascii '{"command": "hi"}'
+```
+
+If your project includes more than one function, or the binary has a different name than the package, you must provide the name of the Lambda function that you want to invoke, and the payload that you want to send. If you don't know how to find your function's name, it can be in two places:
 
 - If your Cargo.toml file includes a `[package]` section, and it does **not** include a `[[bin]]` section, the function's name is in the `name` attribute under the `[package]` section.
 - If your Cargo.toml file includes one or more `[[bin]]` sections, the function's name is in the `name` attribute under the `[[bin]]` section that you want to compile.
+
+In the following example, `basic-lambda` is the function's name as indicated in the package's `[[bin]]` section:
+
+```
+$ cargo lambda invoke basic-lambda --data-ascii '{"command": "hi"}'
+```
 
 Cargo-Lambda compiles functions on demand when they receive the first invocation. It's normal that the first invocation takes a long time if your code has not compiled with the host compiler before. After the first compilation, Cargo-Lambda will re-compile your code every time you make a change in it, without having to send any other invocation requests.
 

--- a/crates/cargo-lambda-invoke/src/lib.rs
+++ b/crates/cargo-lambda-invoke/src/lib.rs
@@ -9,6 +9,13 @@ use std::{
     str::FromStr,
 };
 
+/// Name for the function when no name is provided.
+/// This will make the watch command to compile
+/// the binary without the `--bin` option, and will
+/// assume that the package only has one function,
+/// which is the main binary for that package.
+pub const DEFAULT_PACKAGE_FUNCTION: &str = "@package-bootstrap@";
+
 #[derive(Args, Clone, Debug)]
 #[clap(name = "invoke")]
 pub struct Invoke {
@@ -28,6 +35,7 @@ pub struct Invoke {
     #[clap(long)]
     data_example: Option<String>,
     /// Name of the function to invoke
+    #[clap(default_value = DEFAULT_PACKAGE_FUNCTION)]
     function_name: String,
 }
 

--- a/crates/cargo-lambda-watch/Cargo.toml
+++ b/crates/cargo-lambda-watch/Cargo.toml
@@ -12,6 +12,7 @@ publish = false
 [dependencies]
 axum = "0.5.1"
 cargo-lambda-interactive = { path = "../cargo-lambda-interactive" }
+cargo-lambda-invoke = { path = "../cargo-lambda-invoke" }
 cargo-lambda-metadata = { path = "../cargo-lambda-metadata" }
 clap = { version = "3.1.8", features = ["cargo", "derive"] }
 http-api-problem = { version = "0.51.0", features = ["api-error", "hyper"] }

--- a/crates/cargo-lambda-watch/src/scheduler.rs
+++ b/crates/cargo-lambda-watch/src/scheduler.rs
@@ -1,6 +1,7 @@
 use crate::requests::{InvokeRequest, ServerError};
 use axum::{body::Body, response::Response};
 use cargo_lambda_interactive::command::new_command;
+use cargo_lambda_invoke::DEFAULT_PACKAGE_FUNCTION;
 use cargo_lambda_metadata::{function_metadata, PackageMetadata};
 use std::{
     collections::{hash_map::Entry, HashMap, VecDeque},
@@ -175,8 +176,14 @@ async fn start_function(
         Ok(m) => m.unwrap_or_default(),
     };
 
-    let mut child = new_command("cargo")
-        .args(["watch", "--", "cargo", "run", "--bin", &name])
+    let mut cmd = new_command("cargo");
+    cmd.args(["watch", "--", "cargo", "run"]);
+    if name != DEFAULT_PACKAGE_FUNCTION {
+        cmd.arg("--bin");
+        cmd.arg(&name);
+    }
+
+    let mut child = cmd
         .env("RUST_LOG", std::env::var("RUST_LOG").unwrap_or_default())
         .env("AWS_LAMBDA_FUNCTION_VERSION", "1")
         .env("AWS_LAMBDA_FUNCTION_MEMORY_SIZE", "4096")


### PR DESCRIPTION
For packages that only include one function in the package's
main.rs file, we can compile the code without --bin and give
the function a default name that's not a valid cargo binary name.

Signed-off-by: David Calavera <david.calavera@gmail.com>