### PR TITLE
Download cargo-watch from releases for known platforms.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -296,10 +296,15 @@ dependencies = [
  "cargo-lambda-invoke",
  "cargo-lambda-metadata",
  "clap",
+ "home",
  "http-api-problem",
  "miette",
  "opentelemetry",
  "opentelemetry-aws",
+ "platforms",
+ "reqwest",
+ "tar",
+ "tempfile",
  "thiserror",
  "tokio",
  "tokio-graceful-shutdown",
@@ -309,6 +314,8 @@ dependencies = [
  "tracing-subscriber",
  "uuid",
  "which",
+ "xz2",
+ "zip",
 ]
 
 [[package]]
@@ -559,6 +566,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7896dc8abb250ffdda33912550faa54c88ec8b998dec0b2c55ab224921ce11df"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "fastrand"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf"
+dependencies = [
+ "instant",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "975ccf83d8d9d0d84682850a38c8169027be83368805971cc4f238c2b245bc98"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "winapi",
 ]
 
 [[package]]
@@ -983,6 +1011,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "lzma-sys"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdb4b7c3eddad11d3af9e86c487607d2d2442d185d848575365c4856ba96d619"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "matchers"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1296,6 +1335,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
 
 [[package]]
+name = "platforms"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8d0eef3571242013a0d5dc84861c3ae4a652e56e12adf8bdc26ff5f8cb34c94"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1418,6 +1463,15 @@ name = "regex-syntax"
 version = "0.6.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+
+[[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "reqwest"
@@ -1760,10 +1814,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20518fe4a4c9acf048008599e464deb21beeae3d3578418951a189c235a7a9a8"
 
 [[package]]
+name = "tar"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b55807c0344e1e6c04d7c965f5289c39a8d94ae23ed5c0b57aabac549f871c6"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7fa7e55043acb85fca6b3c01485a2eeb6b69c5d21002e273c79e465f43b7ac1"
+
+[[package]]
+name = "tempfile"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "libc",
+ "redox_syscall",
+ "remove_dir_all",
+ "winapi",
+]
 
 [[package]]
 name = "termcolor"
@@ -2311,6 +2390,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "xattr"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "244c3741f4240ef46274860397c7c74e50eb23624996930e484c16679633a54c"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "xz2"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c179869f34fc7c01830d3ce7ea2086bc3a07e0d35289b667d0a8bf910258926c"
+dependencies = [
+ "lzma-sys",
 ]
 
 [[package]]

--- a/crates/cargo-lambda-watch/Cargo.toml
+++ b/crates/cargo-lambda-watch/Cargo.toml
@@ -15,13 +15,17 @@ cargo-lambda-interactive = { path = "../cargo-lambda-interactive" }
 cargo-lambda-invoke = { path = "../cargo-lambda-invoke" }
 cargo-lambda-metadata = { path = "../cargo-lambda-metadata" }
 clap = { version = "3.1.8", features = ["cargo", "derive"] }
+home = "0.5.3"
 http-api-problem = { version = "0.51.0", features = ["api-error", "hyper"] }
 miette = { version = "4.3.0", features = ["fancy"] }
 opentelemetry = "0.17.0"
 opentelemetry-aws = "0.5.0"
+platforms = "2.0.0"
+reqwest = { version = "0.11.10", default-features = false, features = ["rustls-tls"] }
+tar = "0.4.38"
+tempfile = "3.3.0"
 thiserror = "1.0.30"
 tokio = { version = "1.17.0", features = ["sync", "time"] }
-# tokio = { version = "1.17.0", features = ["full"] }
 tokio-graceful-shutdown = "0.5.0"
 tower-http = { version = "0.2.5", features = ["catch-panic", "request-id", "trace"] }
 tracing = "0.1.32"
@@ -29,3 +33,5 @@ tracing-opentelemetry = "0.17.2"
 tracing-subscriber = { version = "0.3.9", features = ["env-filter"] }
 uuid = { version = "0.8.2", features = ["v4"] }
 which = "4.2.4"
+xz2 = "0.1.6"
+zip = { version = "0.6.2", features = ["bzip2", "deflate", "time"] }

--- a/crates/cargo-lambda-watch/src/scheduler.rs
+++ b/crates/cargo-lambda-watch/src/scheduler.rs
@@ -13,7 +13,7 @@ use tokio::sync::{
     oneshot, Mutex,
 };
 use tokio_graceful_shutdown::SubsystemHandle;
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
 #[derive(Clone)]
 pub(crate) struct RequestQueue {
@@ -170,7 +170,7 @@ async fn start_function(
 
     let meta = match function_metadata(manifest_path, &name) {
         Err(e) => {
-            error!(error = %e, "ignoring invalid function metadata");
+            warn!(error = %e, "ignoring invalid function metadata");
             PackageMetadata::default()
         }
         Ok(m) => m.unwrap_or_default(),

--- a/crates/cargo-lambda-watch/src/watch_installer.rs
+++ b/crates/cargo-lambda-watch/src/watch_installer.rs
@@ -1,0 +1,102 @@
+use cargo_lambda_interactive::{command::silent_command, progress::Progress};
+use home::cargo_home;
+use miette::{IntoDiagnostic, Result, WrapErr};
+use platforms::{
+    platform::{self, Platform},
+    target::OS,
+};
+use reqwest::{get, StatusCode};
+use std::{
+    fs::{rename, File},
+    io::{copy, Cursor},
+};
+use tar::Archive;
+use tempfile::tempdir;
+use xz2::read::XzDecoder;
+use zip::ZipArchive;
+
+const DEFAULT_CARGO_WATCH_VERSION: &str = "v8.1.1";
+const CARGO_WATCH_GITHUB_RELEASES_URL: &str =
+    "https://github.com/watchexec/cargo-watch/releases/download";
+
+pub(crate) async fn install() -> Result<()> {
+    let pb = Progress::start("Installing cargo-watch...");
+
+    let result = match Platform::guess_current() {
+        Some(plat) if is_matching_platform(plat.target_triple) => {
+            download_binary_release(plat).await
+        }
+        _ => silent_command("cargo", &["install", "cargo-watch"]).await,
+    };
+
+    let finish = if result.is_ok() {
+        "cargo-watch installed"
+    } else {
+        "Failed to install cargo-watch"
+    };
+    pb.finish(finish);
+    result
+}
+
+fn is_matching_platform(triple: &str) -> bool {
+    triple == platform::AARCH64_APPLE_DARWIN.target_triple
+        || triple == platform::X86_64_APPLE_DARWIN.target_triple
+        || triple == platform::AARCH64_BE_UNKNOWN_LINUX_GNU.target_triple
+        || triple == platform::X86_64_UNKNOWN_LINUX_GNU.target_triple
+        || triple == platform::AARCH64_PC_WINDOWS_MSVC.target_triple
+        || triple == platform::X86_64_PC_WINDOWS_MSVC.target_triple
+}
+
+async fn download_binary_release(plat: &Platform) -> Result<()> {
+    let version =
+        option_env!("CARGO_LAMBDA_CARGO_WATCH_VERSION").unwrap_or(DEFAULT_CARGO_WATCH_VERSION);
+    let format = if plat.target_os == OS::Windows {
+        "zip"
+    } else {
+        "tar.xz"
+    };
+    let name = format!("cargo-watch-{}-{}.{}", &version, plat.target_triple, format);
+    let url = format!("{}/{}/{}", CARGO_WATCH_GITHUB_RELEASES_URL, version, &name);
+
+    let response = get(&url).await.into_diagnostic()?;
+
+    if response.status() != StatusCode::OK {
+        return Err(miette::miette!(
+            "error downloading cargo-watch binary from {} - {}",
+            url,
+            response.text().await.into_diagnostic()?
+        ));
+    }
+
+    let mut bytes = Cursor::new(response.bytes().await.into_diagnostic()?);
+
+    let tmp_dir = tempdir().into_diagnostic()?;
+    let tmp_path = tmp_dir.path();
+    let tmp_file = tmp_path.join(&name);
+
+    let mut writer = File::create(&tmp_file).into_diagnostic()?;
+    copy(&mut bytes, &mut writer).into_diagnostic()?;
+
+    let reader = File::open(tmp_file).into_diagnostic()?;
+    if plat.target_os == OS::Windows {
+        let mut archive = ZipArchive::new(reader).into_diagnostic()?;
+        archive.extract(&tmp_path).into_diagnostic()?;
+    } else {
+        let tar = XzDecoder::new(reader);
+        let mut archive = Archive::new(tar);
+        archive.unpack(&tmp_path).into_diagnostic()?;
+    }
+
+    let target_file = cargo_home()
+        .into_diagnostic()
+        .wrap_err("missing cargo home")?
+        .join("bin")
+        .join("cargo-watch");
+
+    let original_file = tmp_path.join(&format!(
+        "cargo-watch-{}-{}/cargo-watch",
+        &version, plat.target_triple
+    ));
+
+    rename(original_file, target_file).into_diagnostic()
+}


### PR DESCRIPTION
Fallback to cargo install for other platforms that we don't
know that cargo-watch is compiled statically.

Fixes #46 

Signed-off-by: David Calavera <david.calavera@gmail.com>