### PR TITLE
Fix cargo-watch installation on Windows

### DIFF
--- a/crates/cargo-lambda-watch/Cargo.toml
+++ b/crates/cargo-lambda-watch/Cargo.toml
@@ -22,7 +22,6 @@ opentelemetry = "0.17.0"
 opentelemetry-aws = "0.5.0"
 platforms = "2.0.0"
 reqwest = { version = "0.11.10", default-features = false, features = ["rustls-tls"] }
-tar = "0.4.38"
 tempfile = "3.3.0"
 thiserror = "1.0.30"
 tokio = { version = "1.17.0", features = ["sync", "time"] }
@@ -33,5 +32,10 @@ tracing-opentelemetry = "0.17.2"
 tracing-subscriber = { version = "0.3.9", features = ["env-filter"] }
 uuid = { version = "0.8.2", features = ["v4"] }
 which = "4.2.4"
+
+[target.'cfg(not(windows))'.dependencies]
+tar = "0.4.38"
 xz2 = "0.1.6"
+
+[target.'cfg(windows)'.dependencies]
 zip = { version = "0.6.2", features = ["bzip2", "deflate", "time"] }

--- a/crates/cargo-lambda-watch/src/watch_installer.rs
+++ b/crates/cargo-lambda-watch/src/watch_installer.rs
@@ -20,6 +20,11 @@ const DEFAULT_CARGO_WATCH_VERSION: &str = "v8.1.1";
 const CARGO_WATCH_GITHUB_RELEASES_URL: &str =
     "https://github.com/watchexec/cargo-watch/releases/download";
 
+#[cfg(target_os = "windows")]
+const CARGO_WATCH_BINARY_INFO: (&str, &str) = ("cargo-watch.exe", "zip");
+#[cfg(not(target_os = "windows"))]
+const CARGO_WATCH_BINARY_INFO: (&str, &str) = ("cargo-watch", "tar.xz");
+
 pub(crate) async fn install() -> Result<()> {
     let pb = Progress::start("Installing cargo-watch...");
 
@@ -51,11 +56,7 @@ fn is_matching_platform(triple: &str) -> bool {
 async fn download_binary_release(plat: &Platform) -> Result<()> {
     let version =
         option_env!("CARGO_LAMBDA_CARGO_WATCH_VERSION").unwrap_or(DEFAULT_CARGO_WATCH_VERSION);
-    let (bin_name, format) = if cfg!(target_os = "windows") {
-        ("cargo-watch.exe", "zip")
-    } else {
-        ("cargo-watch", "tar.xz")
-    };
+    let (bin_name, format) = CARGO_WATCH_BINARY_INFO;
 
     let name = format!("cargo-watch-{}-{}.{}", &version, plat.target_triple, format);
     let url = format!("{}/{}/{}", CARGO_WATCH_GITHUB_RELEASES_URL, version, &name);


### PR DESCRIPTION
Make sure the file names are correct.
Use conditional compilation to include less dependencies.

Signed-off-by: David Calavera <david.calavera@gmail.com>