### PR TITLE
Feature: add ```--no-reload``` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ to compile the code for the right architecture. If Zig is not installed in your 
 
 :warning: This subcommand used to be called `start`. Both names still work, as `start` is an alias for `watch`.
 
-The watch subcommand emulates the AWS Lambda control plane API. Run this command at the root of a Rust workspace and cargo-lambda will use cargo-watch to hot compile changes in your Lambda functions.
+The watch subcommand emulates the AWS Lambda control plane API. Run this command at the root of a Rust workspace and cargo-lambda will use cargo-watch to hot compile changes in your Lambda functions. Use flag `--no-reload` to avoid hot compilation.
 
 :warning: This command works best with the **[Lambda Runtime version 0.5.1](https://crates.io/crates/lambda_runtime/0.5.1)**. Previous versions of the rumtime are likely to crash with serialization errors.
 
@@ -182,8 +182,7 @@ cargo lambda invoke http-lambda --data-example apigw-request
 
 After the first download, these examples are cached in your home directory, under `.cargo/lambda/invoke-fixtures`.
 
-[//]: # (badges)
-
+[//]: # 'badges'
 [crate-image]: https://img.shields.io/crates/v/cargo-lambda.svg
 [crate-link]: https://crates.io/crates/cargo-lambda
 [build-image]: https://github.com/calavera/cargo-lambda/workflows/Build/badge.svg

--- a/crates/cargo-lambda-cli/src/main.rs
+++ b/crates/cargo-lambda-cli/src/main.rs
@@ -36,7 +36,7 @@ async fn main() -> Result<()> {
         App::Lambda(lambda) => match *lambda {
             Lambda::Build(mut b) => b.run().await,
             Lambda::Invoke(i) => i.run().await,
-            Lambda::Watch(s) => s.run().await,
+            Lambda::Watch(w) => w.run().await,
         },
         App::Zig(zig) => zig.execute().map_err(|e| miette!(e)),
     }


### PR DESCRIPTION
This pull request includes several suggestions to support #54:

- Change 'watch' subcommand to 'runtime' to better represent what it does. (emulates a runtime)
- Add 'watch' as a flag for runtime. (default is false)
    - Since this is a breaking change the version was bumped to 0.6.0.
    - Because this is not backwards-compatible aliasing to "start" and "watch" have been removed.

The logic behind making watch default to false, instead of a ''--no-watch" flag is this seems to align with other CLIs.
If instead we support a "--no-watch" flag then aliasing can still remain, but obviously command name needs to change, and watch as a command would be pretty silly to support as you can run

```bash
cargo lambda watch --no-watch
```

and get something valid. Start would still be ok but wouldn't behave as before.

Another option is to keep watch, and defer it to runtime with the "--watch" flag. This seems messy as now you have two commands doing virtually the same thing.

Another thing is passing manifest path and watch down the server rabbit hole. Maybe a context struct is in order.

